### PR TITLE
Added basic CSRF protection

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,11 +43,16 @@ function verifyGoogle(req, accessToken, refreshToken, params, profile, done) {
 function verifyAzure(req, accessToken, refreshToken, params, profile, done) {
   // Azure returns an id token with basic information about the user
   var azureProfile = jwt.decode(params.id_token);
+  var state = req.query.state;
+  var parts = state.split('|');
+  var sessionID = parts[0];
+  var csrfToken = parts[1];
 
   // Create a new user object that will be available to
   // the /connect/:providerName/callback route
   var user = {};
-  user.sessionID = req.query.state;
+  user.sessionID = sessionID;
+  user.csrfToken = csrfToken;
   user.providerName = 'azure';
   user.displayName = azureProfile.name;
   user.accessToken = accessToken;

--- a/app.js
+++ b/app.js
@@ -33,7 +33,13 @@ var connect = require('./routes/connect'); // eslint-disable-line vars-on-top
 
 function verifyGoogle(req, accessToken, refreshToken, params, profile, done) {
   var user = {};
-  user.sessionID = req.query.state;
+  var state = req.query.state;
+  var parts = state.split('|');
+  var sessionID = parts[0];
+  var csrfToken = parts[1];
+
+  user.sessionID = sessionID;
+  user.csrfToken = csrfToken;
   user.providerName = profile.provider;
   user.displayName = profile.displayName;
   user.accessToken = accessToken;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "body-parser": "~1.13.2",
     "cookie": "^0.2.3",
     "cookie-parser": "~1.4.0",
+    "csurf": "^1.8.3",
     "express": "~4.13.1",
     "express-session": "^1.12.1",
     "jade": "~1.11.0",

--- a/routes/connect.js
+++ b/routes/connect.js
@@ -27,7 +27,9 @@ router.use(csrf());
 router.get(
   '/google/:sessionID',
   function handleRequest(req, res, next) {
-    authenticationOptions.google.state = req.params.sessionID;
+    // Include the sessionID and csrftToken value in the OAuth state parameter
+    authenticationOptions.google.state = req.params.sessionID + '|' + req.csrfToken();
+    res.cookie('CSRF-TOKEN', req.csrfToken());
     next();
   },
   passport.authenticate('google', authenticationOptions.google)

--- a/routes/connect.js
+++ b/routes/connect.js
@@ -36,7 +36,7 @@ router.get(
 router.get(
   '/azure/:sessionID',
   function handleRequest(req, res, next) {
-    // Include the sessionID and csrftToken value in the OAuth state parameter 
+    // Include the sessionID and csrftToken value in the OAuth state parameter
     authenticationOptions.azure.state = req.params.sessionID + '|' + req.csrfToken();
     res.cookie('CSRF-TOKEN', req.csrfToken());
     next();
@@ -45,18 +45,18 @@ router.get(
 );
 
 router.get('/:providerName/callback', function handleRequest(req, res) {
-  // At the end of the OAuth flow we need to verify that csrfToken in the cookies 
+  // At the end of the OAuth flow we need to verify that csrfToken in the cookies
   // matches the one returned by the OAuth flow
   if (req.cookies['CSRF-TOKEN'] !== req.user.csrfToken) {
     res.render('error', {
-      error : {
+      error: {
         status: 403
-      }, 
-      message : 'Bad or missing CSRF value'
+      },
+      message: 'Bad or missing CSRF value'
     });
     return;
   }
-  
+
   dbHelper.saveAccessToken(
     req.user.sessionID,
     req.params.providerName,

--- a/routes/connect.js
+++ b/routes/connect.js
@@ -8,6 +8,7 @@ var router = express.Router();
 var passport = require('passport');
 var io = require('../app');
 var cookie = require('cookie');
+var csrf = require('csurf');
 var cookieParser = require('cookie-parser');
 var dbHelper = new(require('../db/dbHelper'))();
 var authenticationOptions = {};
@@ -21,6 +22,8 @@ io.on('connection', function onConnection(socket) {
   socket.join(sessionID);
 });
 
+router.use(csrf());
+
 router.get(
   '/google/:sessionID',
   function handleRequest(req, res, next) {
@@ -33,13 +36,27 @@ router.get(
 router.get(
   '/azure/:sessionID',
   function handleRequest(req, res, next) {
-    authenticationOptions.azure.state = req.params.sessionID;
+    // Include the sessionID and csrftToken value in the OAuth state parameter 
+    authenticationOptions.azure.state = req.params.sessionID + '|' + req.csrfToken();
+    res.cookie('CSRF-TOKEN', req.csrfToken());
     next();
   },
   passport.authenticate('azure', authenticationOptions.azure)
 );
 
 router.get('/:providerName/callback', function handleRequest(req, res) {
+  // At the end of the OAuth flow we need to verify that csrfToken in the cookies 
+  // matches the one returned by the OAuth flow
+  if (req.cookies['CSRF-TOKEN'] !== req.user.csrfToken) {
+    res.render('error', {
+      error : {
+        status: 403
+      }, 
+      message : 'Bad or missing CSRF value'
+    });
+    return;
+  }
+  
   dbHelper.saveAccessToken(
     req.user.sessionID,
     req.params.providerName,


### PR DESCRIPTION
This PR adds basic CSRF protection.

We are taking the following actions:

1. We're adding a random value (csrtToken) to the *state* OAuth parameter. The csrtToken takes its value from a cookie created when the popup starts.
2. When the OAuth flow is done, we verify that the cookie exists and that it has the same value than that returned in the *state* parameter.
    1. If the values from the cookie and the state parameters match, the flow continues normally.
    2. If the values from the cookie and the state parameters don't match, the app sends a **403 - Bad or missing CSRF value**.

This prevents the app of serving data to a user who has lured other users into clicking a maliciously forged link.

Update: Thanks to @jtokoph for suggesting this improvement to the sample.