### PR TITLE
Fix design considerations link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A goal of many Microsoft Office add-ins is to improve user productivity. You can
 
 ![Office Add-in Server Authentication Sample screenshot](/readme-images/Office-Add-in-Nodejs-ServerAuth.png)
 
-Keep in mind that Office add-ins run on a variety of platforms and devices, which presents a great opportunity for your add-in. You must be aware, however, of [design considerations](../wiki/Office-add-in-design-considerations-when-using-OAuth-2.0-services) when you try to make OAuth flows work across a combination of platforms and technologies.
+Keep in mind that Office add-ins run on a variety of platforms and devices, which presents a great opportunity for your add-in. You must be aware, however, of [design considerations](https://github.com/OfficeDev/Office-Add-in-Nodejs-ServerAuth/wiki/Office-add-in-design-considerations-when-using-OAuth-2.0-services) when you try to make OAuth flows work across a combination of platforms and technologies.
 
 ## Prerequisites
 


### PR DESCRIPTION
The design considerations link in the readme was leading to a 404 https://github.com/OfficeDev/Office-Add-in-Nodejs-ServerAuth/blob/wiki/Office-add-in-design-considerations-when-using-OAuth-2.0-services
Changed this to a absolute URL to the wiki page.